### PR TITLE
Use git archive to generate the artifact instead of copying .git folder

### DIFF
--- a/src/BaseCommand.php
+++ b/src/BaseCommand.php
@@ -281,7 +281,7 @@ class BaseCommand extends Command implements ConfigurableInterface {
    */
   protected function isGitRepository() {
     $command_output = $this->runCommand('git rev-parse --is-inside-work-tree || true')->getOutput();
-    return $command_output === 'true';
+    return trim($command_output) === 'true';
   }
 
 }

--- a/src/DrupalArtifactBuilderCreate.php
+++ b/src/DrupalArtifactBuilderCreate.php
@@ -74,34 +74,56 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
   }
 
   /**
-   * Copies project .git into the artifact folder and checks out the target branch.
+   * Archives the target branch from origin into the artifact folder via git archive.
    *
-   * Git checkout populates all files — no manual file copying needed.
+   * No .git directory is copied; files are extracted directly from the git object store.
    */
   protected function checkoutBranchInArtifact() {
     $artifactPath = $this->rootFolder . '/' . $this->getArtifactFolder();
     $branch = $this->getConfiguration()->getBranch();
 
-    $this->log(sprintf('Checking out branch "%s" into artifact folder', $branch));
+    $this->log(sprintf('Archiving branch "%s" into artifact folder', $branch));
 
-    $this->runCommand(sprintf('cp -r %s/.git %s/.git', $this->rootFolder, $artifactPath));
     try {
-      $this->runCommandInFolder('git fetch origin', $artifactPath);
+      $this->runCommand(sprintf('git fetch origin %s', escapeshellarg($branch)));
     }
     catch (\Exception $e) {
       $this->output->writeln(sprintf('<warning>[!] git fetch failed, artifact may not reflect the latest remote state: %s</warning>', $e->getMessage()));
     }
+
+    $treeish = 'origin/' . $branch;
     try {
-      $this->runCommandInFolder(sprintf('git checkout -fB %s origin/%s', escapeshellarg($branch), escapeshellarg($branch)), $artifactPath);
+      $this->runCommand(sprintf('git rev-parse --verify %s', escapeshellarg($treeish)));
     }
     catch (\Exception $e) {
-      $this->log(sprintf('Branch "origin/%s" not found in remote, checking out locally', $branch));
-      $this->runCommandInFolder(sprintf('git checkout -fB %s', escapeshellarg($branch)), $artifactPath);
+      $this->log(sprintf('Branch "origin/%s" not found in remote, using local branch', $branch));
+      $treeish = $branch;
     }
 
-    if (file_exists($artifactPath . '/.gitmodules')) {
+    $this->runCommand(sprintf(
+      'git archive %s | tar -xC %s',
+      escapeshellarg($treeish),
+      escapeshellarg($artifactPath)
+    ));
+
+    if (file_exists($this->rootFolder . '/.gitmodules')) {
       $this->log('Initializing git submodules');
-      $this->runCommandInFolder('git submodule update --init', $artifactPath);
+      $this->runCommand('git submodule update --init');
+      $this->runCommand('git submodule update --recursive');
+      $submodulePaths = trim($this->runCommand('git submodule foreach --quiet --recursive pwd')->getOutput());
+      foreach (explode("\n", $submodulePaths) as $submoduleAbsPath) {
+        $submoduleAbsPath = trim($submoduleAbsPath);
+        if (empty($submoduleAbsPath)) {
+          continue;
+        }
+        $submoduleRelPath = ltrim(str_replace($this->rootFolder, '', $submoduleAbsPath), '/');
+        $submoduleArtifactPath = $artifactPath . '/' . $submoduleRelPath;
+        $this->runCommand(sprintf('mkdir -p %s', escapeshellarg($submoduleArtifactPath)));
+        $this->runCommandInFolder(
+          sprintf('git archive HEAD | tar -xC %s', escapeshellarg($submoduleArtifactPath)),
+          $submoduleAbsPath
+        );
+      }
     }
   }
 

--- a/src/DrupalArtifactBuilderCreate.php
+++ b/src/DrupalArtifactBuilderCreate.php
@@ -108,9 +108,9 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
 
     if (file_exists($this->rootFolder . '/.gitmodules')) {
       $this->log('Initializing git submodules included in the artifact');
-      $submodulesToInit = $this->getArtifactSubmodulePaths();
-      if (!empty($submodulesToInit)) {
-        $pathArgs = implode(' ', array_map('escapeshellarg', $submodulesToInit));
+      $submodulesToArchive = $this->getArtifactSubmodulePaths();
+      if (!empty($submodulesToArchive)) {
+        $pathArgs = implode(' ', array_map('escapeshellarg', array_keys($submodulesToArchive)));
         $this->runCommand(sprintf('git submodule update --init -- %s', $pathArgs));
         $this->runCommand(sprintf('git submodule update --recursive -- %s', $pathArgs));
         $submoduleAbsPaths = trim($this->runCommand('git submodule foreach --quiet --recursive pwd')->getOutput());
@@ -122,8 +122,14 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
           $submoduleRelPath = ltrim(str_replace($this->rootFolder, '', $submoduleAbsPath), '/');
           $submoduleArtifactPath = $artifactPath . '/' . $submoduleRelPath;
           $this->runCommand(sprintf('mkdir -p %s', escapeshellarg($submoduleArtifactPath)));
+
+          $subpaths = $submodulesToArchive[$submoduleRelPath] ?? [];
+          $pathspec = '';
+          if (!empty($subpaths)) {
+            $pathspec = ' -- ' . implode(' ', array_map('escapeshellarg', $subpaths));
+          }
           $this->runCommandInFolder(
-            sprintf('git archive HEAD | tar -xC %s', escapeshellarg($submoduleArtifactPath)),
+            sprintf('git archive HEAD%s | tar -xC %s', $pathspec, escapeshellarg($submoduleArtifactPath)),
             $submoduleAbsPath
           );
         }
@@ -184,33 +190,58 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
 
     $patterns = $this->getBaseGitIgnorePatterns($docroot);
 
-    $whitelist = array_merge(
-      $this->getRequiredFiles(),
-      $this->getSymlinks(),
-      array_map(fn($p) => ltrim($p, '/'), $this->getConfiguration()->getInclude()),
-      ['.gitignore']
-    );
+    $whitelist = array_merge($this->getWhitelistPaths(), ['.gitignore']);
+
+    // Ignore every root entry whose top-level segment is not whitelisted.
+    $topLevelKeep = [];
+    foreach ($whitelist as $path) {
+      $segments = explode('/', $path);
+      $topLevelKeep[$segments[0]] = TRUE;
+    }
     $artifactRootEntries = array_filter(
       scandir($artifactPath),
       fn($entry) => !in_array($entry, ['.', '..', '.git'])
     );
-    foreach (array_diff($artifactRootEntries, $whitelist) as $extra) {
-      $patterns[] = '/' . $extra;
+    foreach ($artifactRootEntries as $entry) {
+      if (!isset($topLevelKeep[$entry])) {
+        $patterns[] = '/' . $entry;
+      }
+    }
+
+    // For each deep whitelist path, emit the gitignore ladder so every
+    // ancestor stays reachable but siblings at each level are ignored.
+    $emitted = [];
+    foreach ($whitelist as $path) {
+      $segments = explode('/', $path);
+      if (count($segments) < 2) {
+        continue;
+      }
+      $prefix = '';
+      for ($i = 0, $n = count($segments) - 1; $i < $n; $i++) {
+        $prefix .= '/' . $segments[$i];
+        $ignoreSiblings = $prefix . '/*';
+        $unignoreChild = '!' . $prefix . '/' . $segments[$i + 1];
+        if (!isset($emitted[$ignoreSiblings])) {
+          $patterns[] = $ignoreSiblings;
+          $emitted[$ignoreSiblings] = TRUE;
+        }
+        if (!isset($emitted[$unignoreChild])) {
+          $patterns[] = $unignoreChild;
+          $emitted[$unignoreChild] = TRUE;
+        }
+      }
     }
 
     foreach ($this->getConfiguration()->getExclude() as $excludePath) {
       $patterns[] = $excludePath;
     }
 
+    // For include entries that point at a file, an explicit negation is
+    // needed because the ladder above only re-includes directory segments.
     foreach ($this->getConfiguration()->getInclude() as $includePath) {
-      $normalizedPath = '/' . ltrim($includePath, '/');
-      if (is_file($artifactPath . '/' . ltrim($includePath, '/'))) {
-        $patterns[] = '!' . $normalizedPath;
-      }
-      else {
-        $patterns = array_values(array_filter($patterns, function ($pattern) use ($normalizedPath) {
-          return $pattern !== $normalizedPath && $pattern !== rtrim($normalizedPath, '/') . '/';
-        }));
+      $relative = ltrim($includePath, '/');
+      if (is_file($artifactPath . '/' . $relative)) {
+        $patterns[] = '!/' . $relative;
       }
     }
 
@@ -295,43 +326,95 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
   }
 
   /**
-   * Returns submodule paths that fall under artifact-included directories.
+   * Returns submodule paths that intersect artifact-included paths.
    *
-   * @return string[]
+   * @return array<string, string[]>
+   *   Map of submodule path => list of subpaths (relative to the submodule
+   *   root) that must be archived. An empty list means archive the whole
+   *   submodule.
    */
   protected function getArtifactSubmodulePaths(): array {
-    $includedPaths = array_merge(
-      $this->getRequiredFiles(),
-      $this->getSymlinks(),
-      array_map(fn($p) => ltrim($p, '/'), $this->getConfiguration()->getInclude())
-    );
+    $includedPaths = $this->getWhitelistPaths();
 
     $output = trim($this->runCommand('git config --file .gitmodules --get-regexp \'\.path$\'')->getOutput());
     if (empty($output)) {
       return [];
     }
 
-    $submodulePaths = [];
+    $submodules = [];
     foreach (explode("\n", $output) as $line) {
       $parts = preg_split('/\s+/', trim($line), 2);
-      $submodulePath = $parts[1] ?? '';
+      $submodulePath = trim($parts[1] ?? '');
       if (empty($submodulePath)) {
         continue;
       }
+
+      $subpaths = [];
+      $wholeSubmodule = FALSE;
       foreach ($includedPaths as $includedPath) {
-        if ($submodulePath === $includedPath || str_starts_with($submodulePath, rtrim($includedPath, '/') . '/')) {
-          $submodulePaths[] = $submodulePath;
+        if ($includedPath === $submodulePath || $this->pathIsAtOrUnder($submodulePath, $includedPath)) {
+          // The include covers the entire submodule (use case 1).
+          $wholeSubmodule = TRUE;
           break;
         }
+        if ($this->pathIsAtOrUnder($includedPath, $submodulePath)) {
+          // The include is a subpath inside the submodule (use case 2).
+          $subpaths[] = substr($includedPath, strlen($submodulePath) + 1);
+        }
+      }
+
+      if ($wholeSubmodule) {
+        $submodules[$submodulePath] = [];
+      }
+      elseif (!empty($subpaths)) {
+        $submodules[$submodulePath] = array_values(array_unique($subpaths));
       }
     }
 
+    $log = [];
+    foreach ($submodules as $path => $subpaths) {
+      $log[] = empty($subpaths) ? $path : ($path . ' (subpaths: ' . implode(', ', $subpaths) . ')');
+    }
     $this->log(sprintf(
       'Submodules included in artifact: %s',
-      empty($submodulePaths) ? '(none)' : implode(', ', $submodulePaths)
+      empty($log) ? '(none)' : implode('; ', $log)
     ));
 
-    return $submodulePaths;
+    return $submodules;
+  }
+
+  /**
+   * Returns the full whitelist of paths that must end up in the artifact.
+   *
+   * @return string[]
+   *   Normalised paths (no leading slash, no trailing slash).
+   */
+  protected function getWhitelistPaths(): array {
+    $paths = array_merge(
+      $this->getRequiredFiles(),
+      $this->getSymlinks(),
+      $this->getConfiguration()->getInclude()
+    );
+    $normalised = [];
+    foreach ($paths as $path) {
+      $path = trim($path, '/');
+      if ($path !== '') {
+        $normalised[$path] = $path;
+      }
+    }
+    return array_values($normalised);
+  }
+
+  /**
+   * Whether $candidate is at or under $parent (segment-wise).
+   */
+  protected function pathIsAtOrUnder(string $candidate, string $parent): bool {
+    $candidate = trim($candidate, '/');
+    $parent = trim($parent, '/');
+    if ($candidate === $parent) {
+      return TRUE;
+    }
+    return str_starts_with($candidate, $parent . '/');
   }
 
   /**

--- a/src/DrupalArtifactBuilderCreate.php
+++ b/src/DrupalArtifactBuilderCreate.php
@@ -107,22 +107,26 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
     ));
 
     if (file_exists($this->rootFolder . '/.gitmodules')) {
-      $this->log('Initializing git submodules');
-      $this->runCommand('git submodule update --init');
-      $this->runCommand('git submodule update --recursive');
-      $submodulePaths = trim($this->runCommand('git submodule foreach --quiet --recursive pwd')->getOutput());
-      foreach (explode("\n", $submodulePaths) as $submoduleAbsPath) {
-        $submoduleAbsPath = trim($submoduleAbsPath);
-        if (empty($submoduleAbsPath)) {
-          continue;
+      $this->log('Initializing git submodules included in the artifact');
+      $submodulesToInit = $this->getArtifactSubmodulePaths();
+      if (!empty($submodulesToInit)) {
+        $pathArgs = implode(' ', array_map('escapeshellarg', $submodulesToInit));
+        $this->runCommand(sprintf('git submodule update --init -- %s', $pathArgs));
+        $this->runCommand(sprintf('git submodule update --recursive -- %s', $pathArgs));
+        $submoduleAbsPaths = trim($this->runCommand('git submodule foreach --quiet --recursive pwd')->getOutput());
+        foreach (explode("\n", $submoduleAbsPaths) as $submoduleAbsPath) {
+          $submoduleAbsPath = trim($submoduleAbsPath);
+          if (empty($submoduleAbsPath)) {
+            continue;
+          }
+          $submoduleRelPath = ltrim(str_replace($this->rootFolder, '', $submoduleAbsPath), '/');
+          $submoduleArtifactPath = $artifactPath . '/' . $submoduleRelPath;
+          $this->runCommand(sprintf('mkdir -p %s', escapeshellarg($submoduleArtifactPath)));
+          $this->runCommandInFolder(
+            sprintf('git archive HEAD | tar -xC %s', escapeshellarg($submoduleArtifactPath)),
+            $submoduleAbsPath
+          );
         }
-        $submoduleRelPath = ltrim(str_replace($this->rootFolder, '', $submoduleAbsPath), '/');
-        $submoduleArtifactPath = $artifactPath . '/' . $submoduleRelPath;
-        $this->runCommand(sprintf('mkdir -p %s', escapeshellarg($submoduleArtifactPath)));
-        $this->runCommandInFolder(
-          sprintf('git archive HEAD | tar -xC %s', escapeshellarg($submoduleArtifactPath)),
-          $submoduleAbsPath
-        );
       }
     }
   }
@@ -288,6 +292,46 @@ class DrupalArtifactBuilderCreate extends BaseCommand {
       "**/UPDATE.txt",
       "**/USAGE.txt"
     ];
+  }
+
+  /**
+   * Returns submodule paths that fall under artifact-included directories.
+   *
+   * @return string[]
+   */
+  protected function getArtifactSubmodulePaths(): array {
+    $includedPaths = array_merge(
+      $this->getRequiredFiles(),
+      $this->getSymlinks(),
+      array_map(fn($p) => ltrim($p, '/'), $this->getConfiguration()->getInclude())
+    );
+
+    $output = trim($this->runCommand('git config --file .gitmodules --get-regexp \'\.path$\'')->getOutput());
+    if (empty($output)) {
+      return [];
+    }
+
+    $submodulePaths = [];
+    foreach (explode("\n", $output) as $line) {
+      $parts = preg_split('/\s+/', trim($line), 2);
+      $submodulePath = $parts[1] ?? '';
+      if (empty($submodulePath)) {
+        continue;
+      }
+      foreach ($includedPaths as $includedPath) {
+        if ($submodulePath === $includedPath || str_starts_with($submodulePath, rtrim($includedPath, '/') . '/')) {
+          $submodulePaths[] = $submodulePath;
+          break;
+        }
+      }
+    }
+
+    $this->log(sprintf(
+      'Submodules included in artifact: %s',
+      empty($submodulePaths) ? '(none)' : implode(', ', $submodulePaths)
+    ));
+
+    return $submodulePaths;
   }
 
   /**


### PR DESCRIPTION
In the create command, using the .git may be a slow process because , in local environments, it may contain all the git registry. That implies copying folders with lots of files that may have more than 1G of space.

Using git archive can solve this problem. This PR fixes that, and also takes in account git submodules.